### PR TITLE
Handle annotations and locations better

### DIFF
--- a/src/hidden_pipe.erl
+++ b/src/hidden_pipe.erl
@@ -89,7 +89,7 @@ parse_transform(Forms, _Options) ->
     NewForms.
 
 
-form({function, Line, Name, Arity, Clauses}) ->
+form({function, Anno, Name, Arity, Clauses}) ->
     SubstituteVarNameBin = atom_to_binary(get(?TO_SUBSTITUTE), utf8),
     VarNamesList = lists:flatten(var_names(Clauses)),
     case maps:from_list([{atom_to_binary(VarName, utf8), VarName} || VarName <- VarNamesList]) of
@@ -97,15 +97,15 @@ form({function, Line, Name, Arity, Clauses}) ->
             put(?STACK, []),
             put(?FUN_NAME, Name),
             put(?VAR_NAMES, VarNames),
-            {function, Line, Name, Arity, [clause(Clause) || Clause <- Clauses]};
+            {function, Anno, Name, Arity, [clause(Clause) || Clause <- Clauses]};
         _ ->
-            {function, Line, Name, Arity, Clauses}
+            {function, Anno, Name, Arity, Clauses}
     end;
 form(F) ->  F.
 
 
-clause({clause,Line,Head,Guard,Body}) ->
-    {clause, Line, Head, Guard, exprs(Body)}.
+clause({clause,Anno,Head,Guard,Body}) ->
+    {clause, Anno, Head, Guard, exprs(Body)}.
 
 
 exprs([]) -> [];
@@ -114,8 +114,8 @@ exprs([H | T]) ->
     put(?STACK, [erase(?VAR_SUBSTITUTION) | get(?STACK)]),
     exprs_tail(expr(H), T).
 exprs_tail(Previous, [Current| RestExpressions]) ->
-    Line = element(2, Previous),
-    put(?VAR_SUBSTITUTION, {line, Line}),
+    Anno = element(2, Previous),
+    put(?VAR_SUBSTITUTION, {line, Anno}),
 
     % If the new var was used in Current, add a match to Previous
     ParsedCurrent = expr(Current),
@@ -123,11 +123,11 @@ exprs_tail(Previous, [Current| RestExpressions]) ->
          {atom, NewVarNameAtom} ->
              case get(?VERBOSE) of
                  true ->
-                    PrintArgs = [?MODULE, get(?MODULE_NAME), get(?FUN_NAME), Line],
+                    PrintArgs = [?MODULE, get(?MODULE_NAME), get(?FUN_NAME), Anno],
                     io:format("~p: ~p:~p:~p Used in next expression~n", PrintArgs);
                  _ -> ok
              end,
-             {match, Line, {var, Line, NewVarNameAtom}, Previous};
+             {match, Anno, {var, Anno, NewVarNameAtom}, Previous};
          _ -> Previous
      end | exprs_tail(ParsedCurrent, RestExpressions)];
 exprs_tail(PreviousExpression, []) ->
@@ -140,10 +140,10 @@ exprs_tail(PreviousExpression, []) ->
 
 % If the name for the variable to be substituted is found, substitute it
 % (creating a new var if required)
-expr({var, Line, OriginalVarName}) ->
-    {var, Line, case {get(?TO_SUBSTITUTE), get(?VAR_SUBSTITUTION)} of
-                    {OriginalVarName, {line, ExpressionLine}} ->
-                        NewVarNameAtom = binary_to_atom(new_var_name(ExpressionLine), utf8),
+expr({var, Anno, OriginalVarName}) ->
+    {var, Anno, case {get(?TO_SUBSTITUTE), get(?VAR_SUBSTITUTION)} of
+                    {OriginalVarName, {line, ExpressionAnno}} ->
+                        NewVarNameAtom = binary_to_atom(new_var_name(ExpressionAnno), utf8),
                         put(?VAR_SUBSTITUTION, {atom, NewVarNameAtom}),
                         NewVarNameAtom;
                     {OriginalVarName, {atom, VarNameAtom}} ->  VarNameAtom;
@@ -152,21 +152,21 @@ expr({var, Line, OriginalVarName}) ->
 
 % Push to expression block stack
 % These create new blocks of expressions,  so they need to call exprs
-expr({block, Line, Es}) -> {block, Line, exprs(Es)};
-expr({'case', Line, E, Cs}) -> {'case', Line,  expr(E),  [clause(C) || C <- Cs]};
-expr({'if', Line, Cs}) -> {'if', Line, [clause(C) || C <- Cs]};
-expr({'receive', Line, Cs}) -> {'receive', Line, [clause(C) || C <- Cs]};
-expr({'receive', Line, Cs, To, ToEs}) -> {'receive', Line, [clause(C) || C <- Cs], expr(To), exprs(ToEs)};
-expr({'try', Line, Es, Scs, Ccs, As}) -> {'try', Line, exprs(Es), [clause(Sc) || Sc <- Scs], [clause(Cc) || Cc <- Ccs], exprs(As)};
-expr({named_fun, Line, Name, Cs}) -> {named_fun, Line, Name, [clause(C) || C <- Cs]};
-expr({'fun', Line, {clauses, Cs}}) -> {'fun', Line, {clauses, [clause(C) || C <- Cs]}};
+expr({block, Anno, Es}) -> {block, Anno, exprs(Es)};
+expr({'case', Anno, E, Cs}) -> {'case', Anno,  expr(E),  [clause(C) || C <- Cs]};
+expr({'if', Anno, Cs}) -> {'if', Anno, [clause(C) || C <- Cs]};
+expr({'receive', Anno, Cs}) -> {'receive', Anno, [clause(C) || C <- Cs]};
+expr({'receive', Anno, Cs, To, ToEs}) -> {'receive', Anno, [clause(C) || C <- Cs], expr(To), exprs(ToEs)};
+expr({'try', Anno, Es, Scs, Ccs, As}) -> {'try', Anno, exprs(Es), [clause(Sc) || Sc <- Scs], [clause(Cc) || Cc <- Ccs], exprs(As)};
+expr({named_fun, Anno, Name, Cs}) -> {named_fun, Anno, Name, [clause(C) || C <- Cs]};
+expr({'fun', Anno, {clauses, Cs}}) -> {'fun', Anno, {clauses, [clause(C) || C <- Cs]}};
 
 % Patterns here (list/binary comprehension + match)
 % Since these contain Patterns, they need to be iterated 'manually' to avoid
 % modifying the patterns
-expr({lc, Line, E, Qs}) -> {lc, Line, expr(E), [lc_bc_qual(Q) || Q <- Qs]};
-expr({bc, Line, E, Qs}) -> {bc, Line, expr(E), [lc_bc_qual(Q) || Q <- Qs]};
-expr({match, Line, P, E}) -> {match, Line, P, expr(E)};
+expr({lc, Anno, E, Qs}) -> {lc, Anno, expr(E), [lc_bc_qual(Q) || Q <- Qs]};
+expr({bc, Anno, E, Qs}) -> {bc, Anno, expr(E), [lc_bc_qual(Q) || Q <- Qs]};
+expr({match, Anno, P, E}) -> {match, Anno, P, expr(E)};
 
 % Default tree search
 expr(Es) when is_list(Es) -> [expr(E) || E <- Es];
@@ -176,8 +176,8 @@ expr(E) when is_tuple(E), tuple_size(E) > 2 ->
 expr(E) -> E.
 
 
-lc_bc_qual({generate,Line,P,E}) -> {generate,Line,P,expr(E)};
-lc_bc_qual({b_generate,Line,P,E}) -> {b_generate,Line,P,expr(E)};
+lc_bc_qual({generate,Anno,P,E}) -> {generate,Anno,P,expr(E)};
+lc_bc_qual({b_generate,Anno,P,E}) -> {b_generate,Anno,P,expr(E)};
 lc_bc_qual(E0) -> expr(E0).
 
 
@@ -185,21 +185,21 @@ lc_bc_qual(E0) -> expr(E0).
 %% Aux functions
 %%====================================================================
 
-var_names({var, _Line, VarName}) -> [VarName];
+var_names({var, _Anno, VarName}) -> [VarName];
 var_names([]) -> [];
 var_names([H | T]) -> [var_names(H) | var_names(T)];
 var_names(T) when is_tuple(T), tuple_size(T) > 2 -> var_names(tl(tl(tuple_to_list(T))));
 var_names(_T) -> [].
 
 
-new_var_name(Line) ->
-    new_var_name(Line, get(?VAR_NAMES)).
-new_var_name(Line, VarNames) ->
+new_var_name(Anno) ->
+    new_var_name(Anno, get(?VAR_NAMES)).
+new_var_name(Anno, VarNames) ->
     Index = put(?VAR_INDEX, get(?VAR_INDEX) + 1),
-    Candidate = <<"_", (integer_to_binary(Line))/binary, "_", (integer_to_binary(Index))/binary>>,
+    Candidate = <<"_", (integer_to_binary(erl_anno:line(Anno)))/binary, "_", (integer_to_binary(Index))/binary>>,
     case VarNames of
         #{Candidate := _} ->
-            new_var_name(Line, VarNames);
+            new_var_name(Anno, VarNames);
         _ ->
             Candidate
     end.


### PR DESCRIPTION
This PR is one of several affecting repositories on Github. It
aims at fixing bad use of annotations (see erl_anno(3)). The
following remarks are common to all PR:s.

Typically the second element of abstract code tuples is assumed
to be an integer, which is no longer always true. For instance,
the parse transform implementing QLC tables (see qlc(3)) returns
code where some annotations are marked as `generated'. Such an
annotation is a list, not an integer (it used to be a negative
integer).

As of Erlang/OTP 24.0, the location can be a tuple {Line, Column},
which is another reason to handle annotations properly.